### PR TITLE
Fix wheels release

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           package-dir: ./
           output-dir: ./wheelhouse
+          only: ${{ matrix.only }}
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Seems like `cibuildwheel` requires `--only` to be non-empty.